### PR TITLE
Refresh

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -18,12 +18,13 @@ module.exports =
         filePath = textEditor.getPath()
         command = atom.config.get('linter-perlcritic.executablePath') or @config.executablePath.default
         parameters = []
-        parameters.push(filePath)
+        parameters.push '--verbose'
+        parameters.push '8'
+        parameters.push filePath
         text = textEditor.getText()
         return helpers.exec(command, parameters).then (output) ->
           errors = for message in helpers.parse(output, regex, {filePath: filePath})
             message.type = 'error'
             message
 
-          console.dir errors
           return errors

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-perlcritic",
   "linter-package": true,
-  "main": "./lib/init",
+  "main": "./lib/main",
   "version": "0.1.1",
   "description": "Linter plugin for perl, using perlcritic",
   "keywords": [],
@@ -10,5 +10,14 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "atom-linter": "^3.0.0"
+  },
+  "providedServices": {
+    "linter": {
+      "versions": {
+        "1.0.0": "provideLinter"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Of course I forgot to include some stuff in the `package.json` so that AtomLinter recognizes the plugin. This should work now. I also forced perlcritic to use verbosity level 8 so that we always get the line/col position of the errors (and I like to see the Perl package that causes the error so I can read more about it or disable it).