### PR TITLE
Update the RegEx and other fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,38 @@
+{
+  "max_line_length": {
+    "value": 120,
+    "level": "warn"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  },
+  "arrow_spacing": {
+    "level": "error"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "error"
+  },
+  "prefer_english_operator": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "spacing": {
+      "left": 0,
+      "right": 1
+    },
+    "level": "error"
+  },
+  "braces_spacing": {
+    "spaces": 0,
+    "level": "error"
+  },
+  "spacing_after_comma": {
+    "level": "error"
+  },
+  "no_stand_alone_at": {
+    "level": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     }
   },
   "dependencies": {
-    "atom-linter": "^3.0.0",
-    "atom-package-deps": "^2.0.0"
+    "atom-linter": "^3.1.0",
+    "atom-package-deps": "^2.1.3"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Updates the RegEx to match the output found in `perlcritic` v1.126.
Fixes and/or improves several other aspects of the package like:
* Settings are now subscribed to
* lintOnFly should actually be true now, it shouldn't have been before as this used to be file based.
* Adds a coffeelint.json for code consistency
* Add a .gitattributes specifying that EOL should be handled automatically (LF in the repo, client default when checked out)
* Update package.json dependencies to the true required minimum versions.