### PR TITLE
Add command line options setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.2 - 2016-02-07
+* Add option to specify addiitonal commandline options
+
 ## 0.1.1 - 2015-08-15
 * Updated to be compatible with new version of AtomLinter
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -16,6 +16,10 @@ module.exports =
       type: 'string'
       title: 'Perlcritic Level of warning'
       default: 'Info'
+    commandlineOptions:
+      type: 'string'
+      title: 'Additional Commandline options'
+      default: ''
 
 
   activate: ->
@@ -34,6 +38,7 @@ module.exports =
             fileDir = Path.dirname(filePath)
             command = atom.config.get('linter-perlcritic.executablePath')
             parameters = []
+            parameters.push(atom.config.get('linter-perlcritic.commandlineOptions'))
             parameters.push('-')
             text = textEditor.getText()
             return helpers.exec(command, parameters, {stdin: text, cwd: fileDir}).then (output) ->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-perlcritic",
   "main": "./lib/init",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Linter plugin for perl, using perlcritic",
   "keywords": [],
   "repository": "https://github.com/whity/atom-linter-perlcritic.git",


### PR DESCRIPTION
allow additional command line options to be passed in via settings.

Usage example is utilising a package that provides use strict and use warnings (Packages like Modern::Perl, Mojolicious etc).

critic will not always recognize this and still warns of code before strictures, this change allows `--exclude=strict` to be added to the perlcritic command line and prevent these incorrect warnings.